### PR TITLE
Remove buildpack.yml file

### DIFF
--- a/buildpack.yml
+++ b/buildpack.yml
@@ -1,5 +1,0 @@
-php:
-  version: 7.4.x
-  script: index.php
-  webserver: nginx
-  webdirectory: wordpress


### PR DESCRIPTION
Deployment fails if there is a `buildpack.yml` file and we don't need it anymore after all.
This PR will fix failed tests in the CI => https://github.com/epinio/epinio/pull/1421